### PR TITLE
Hotfix wbid case

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,9 @@
           :dependencies [[compojure "1.6.0"]
                          [ring/ring-defaults "0.3.0"]
                          [ring/ring-core "1.6.2"]
-                         [ring/ring-json "0.4.0"]]
+                         [ring/ring-json "0.4.0"]
+                         ;; use jetty in tests
+                         [ring/ring-jetty-adapter "1.6.3"]]
           :ring {:handler wb-es.web.index/handler
                  :init wb-es.web.setup/run}}]
    :web-dev {:dependencies [[ring/ring-devel "1.5.1"]]

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -13,7 +13,7 @@
 (def generic-mapping
   {:properties
    {:wbid {:type "string"
-           :analyzer "keyword"
+           :analyzer "keyword_ignore_case"
            :include_in_all false
            :fields {:autocomplete_keyword {:type "string"
                                            :analyzer "autocomplete"

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -11,15 +11,16 @@
    [wb-es.datomic.db :refer [datomic-conn]]
    [wb-es.env :refer [es-base-url]]
    [wb-es.mappings.core :as mappings]
-   [wb-es.web.index :refer [handler]]
+   [wb-es.web.index :refer [make-handler]]
    [wb-es.web.core :as web])
   )
 
 (def index-name "test")
 
 (mount/defstate test-server
-  :start (run-jetty handler {:port 0 ;find available ones
-                             :join? false})
+  :start (let [handler (make-handler index-name)]
+           (run-jetty handler  {:port 0 ;find available ones
+                                :join? false}))
   :stop (.stop test-server))
 
 (mount/defstate test-server-uri

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -88,7 +88,15 @@
 (deftest server-start-test
   (testing "server started"
     (let [response (http/get test-server-uri)]
-      (is (= 200 (:status response))))))
+      (is (= 200 (:status response)))))
+  (testing "server using correct index"
+    (let [db (d/db datomic-conn)]
+      (do
+        (index-datomic-entity (d/entity db [:gene/id "WBGene00000904"]))
+        (let [hit (-> (search "WBGene00000904")
+                      (get-in [:hits :hits 0]))]
+          (is (= "WBGene00000904" (get-in hit [:_source :wbid])))
+          (is (= index-name (:_index hit))))))))
 
 (deftest anatomy-type-test
   (testing "anatomy type using \"tl\" prefixed terms"

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -45,6 +45,9 @@
                              :body (->> (assoc-in mappings/index-settings [:settings :number_of_shards] 1)
                                         (json/generate-string))})
         (mount/start)
+        (if test-server-uri
+          (println (format "Testing server is started at %s" test-server-uri))
+          (println "Testing server failed to start"))
         (f)
         (mount/stop))
       )))
@@ -84,9 +87,8 @@
 
 (deftest server-start-test
   (testing "server started"
-    (try
-      (prn test-server-uri)
-      (prn (http/get test-server-uri)))))
+    (let [response (http/get test-server-uri)]
+      (is (= 200 (:status response))))))
 
 (deftest anatomy-type-test
   (testing "anatomy type using \"tl\" prefixed terms"

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -63,16 +63,6 @@
        (map create-document)
        (apply index-doc)))
 
-;; (defn with-default-options
-;;   "create a new search func that "
-;;   [search-func]
-;;   (fn [& search-args]
-;;     (let [[q options] search-args]
-;;       (search-func es-base-url
-;;                    index-name
-;;                    q
-;;                    (or options {})))))
-
 (defn web-query
   "returns a function that submits a web query and parses its results"
   [path]


### PR DESCRIPTION
- Ignore case in wbid when indexing
- fix test case by testing against a test server rather than "unit testing", because wrappers/middleware on the server normalizes the input before feeding them into the handler.