### PR TITLE
Delete old index when running the bulk indexer

### DIFF
--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -109,7 +109,9 @@
                    index-id (format "%s_v%s" release-id index-revision-number)}}]
   (let []
     (do
-      (create-index index-id :default-index (= index-revision-number 0))
+      (create-index index-id
+                    :default-index (= index-revision-number 0)
+                    :delete-existing true)
       (let [n-threads 4
             scheduler (chan n-threads)
             logger (chan n-threads)]

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -11,6 +11,7 @@
             [wb-es.datomic.db :refer [datomic-conn]]
             [wb-es.env :refer [es-base-url release-id]]
             [wb-es.mappings.core :refer [create-index]]
+            [wb-es.web.setup :refer [es-connect]]
             [wb-es.snapshot.core :refer [connect-snapshot-repository save-snapshot get-next-snapshot-id]]))
 
 (defn format-bulk
@@ -353,6 +354,7 @@
   "I don't do a whole lot ... yet."
   [& args]
   (do
+    (es-connect)
     (println "Indexer starting!")
     (mount/start)
     (if-let [index-revision-number (first args)]

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -77,14 +77,23 @@
    :mappings {:generic generic-mapping}})
 
 (defn create-index
-  ([index & {:keys [default-index]}]
+  ([index & {:keys [default-index delete-existing]}]
      (let [index-url (format "%s/%s " es-base-url index)
            settings (if default-index
                       (assoc-in index-settings [:aliases release-id] {})
                       index-settings)]
-       (try
-         (http/put index-url {:headers {:content-type "application/json"}
-                              :body (json/generate-string settings)})
-         (catch clojure.lang.ExceptionInfo e
-           (clojure.pprint/pprint (ex-data e))
-           (throw e))))))
+       (do
+         (if delete-existing
+           (try
+             (http/delete index-url)
+             (catch clojure.lang.ExceptionInfo e
+               (if-not (= (:status (ex-data e))
+                          404)
+                 (clojure.pprint/pprint (ex-data e))))))
+         (try
+           (http/put index-url {:headers {:content-type "application/json"}
+                                :body (json/generate-string settings)})
+           (catch clojure.lang.ExceptionInfo e
+             (clojure.pprint/pprint (ex-data e))
+             (throw e))))
+       )))

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -78,9 +78,13 @@
 
 (defn create-index
   ([index & {:keys [default-index]}]
-   (let [index-url (format "%s/%s " es-base-url index)
-         settings (if default-index
-                    (assoc-in index-settings [:aliases release-id] {})
-                    index-settings)]
-     (http/put index-url {:headers {:content-type "application/json"}
-                          :body (json/generate-string settings)}))))
+     (let [index-url (format "%s/%s " es-base-url index)
+           settings (if default-index
+                      (assoc-in index-settings [:aliases release-id] {})
+                      index-settings)]
+       (try
+         (http/put index-url {:headers {:content-type "application/json"}
+                              :body (json/generate-string settings)})
+         (catch clojure.lang.ExceptionInfo e
+           (clojure.pprint/pprint (ex-data e))
+           (throw e))))))


### PR DESCRIPTION
This allows the indexer environment on EB to be restarted from a rebuilt, without triggering a failure due to an index already exist.