### PR TITLE
Upgrade to elasticsearch 6.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pom.xml.asc
 **/.elasticbeanstalk/*
 !**/.elasticbeanstalk/*.cfg.yml
 !**/.elasticbeanstalk/*.global.yml
+
+# emacs
+*~

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ docker-build-aws-es:
 
 .PHONY: docker-run-aws-es
 docker-run-aws-es:
+	@docker rm -f elasticsearch
 	@docker run -p 9200:9200 \
 		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
 		-e AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY} \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,15 @@ docker-run-aws-es:
 		-e AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY} \
 		--ulimit nofile=65536:65536 \
 		-v /var/lib/elasticsearch/data:/usr/share/elasticsearch/data \
+		--network wb-network \
+		--name elasticsearch \
 		wormbase/aws-elasticsearch
+
+.PHONY: docker-run-kibana
+docker-run-kibana:
+	@docker run -p 5601:5601 \
+		--network=wb-network \
+		docker.elastic.co/kibana/kibana
 
 .PHONY: eb-local-run
 eb-local-run:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 all: docker-build-web
 
 .PHONY: uberjar-build-web
@@ -35,10 +36,11 @@ docker-build-aws-es:
 .PHONY: docker-run-aws-es
 docker-run-aws-es:
 	@docker run -p 9200:9200 \
+		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+		-e AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY} \
+		--ulimit nofile=65536:65536 \
 		-v /var/lib/elasticsearch/data:/usr/share/elasticsearch/data \
-		wormbase/aws-elasticsearch \
-		-Des.cloud.aws.access_key=${AWS_ACCESS_KEY_ID} \
-		-Des.cloud.aws.secret_key=${AWS_SECRET_ACCESS_KEY}
+		wormbase/aws-elasticsearch
 
 .PHONY: eb-local-run
 eb-local-run:

--- a/docker/Dockerfile.aws-elasticsearch
+++ b/docker/Dockerfile.aws-elasticsearch
@@ -1,14 +1,22 @@
-FROM elasticsearch:2.4.6-alpine
+FROM elasticsearch:6.6.1
 
 USER root
 WORKDIR /usr/share/elasticsearch
-RUN bin/plugin install cloud-aws
+RUN yes | bin/elasticsearch-plugin install discovery-ec2
+RUN yes | bin/elasticsearch-plugin install repository-s3
+
 USER elasticsearch
 
 ADD ./docker/elasticsearch-config/elasticsearch.yml /usr/share/elasticsearch/config
 ADD ./docker/elasticsearch-config/logging.yml /usr/share/elasticsearch/config
+ADD ./docker/es-entrypoint.sh /usr/share/elasticsearch/custom-docker-entrypoint.sh
 USER root
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+RUN chown elasticsearch:elasticsearch custom-docker-entrypoint.sh
+RUN chmod u+x custom-docker-entrypoint.sh
+
 USER elasticsearch
+
+ENTRYPOINT ["/usr/share/elasticsearch/custom-docker-entrypoint.sh"]
 
 EXPOSE 9200

--- a/docker/elasticsearch-config/elasticsearch.yml
+++ b/docker/elasticsearch-config/elasticsearch.yml
@@ -93,5 +93,5 @@ network.host: 0.0.0.0
 #
 # action.destructive_requires_name: true
 
-script.inline: true
-script.indexed: true
+# script.inline: true
+# script.indexed: true

--- a/docker/es-entrypoint.sh
+++ b/docker/es-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+bin/elasticsearch-keystore create
+
+# credentials for AWS S3 repository plugin
+echo ${AWS_ACCESS_KEY_ID} | bin/elasticsearch-keystore add --stdin s3.client.default.access_key
+echo ${AWS_SECRET_KEY} | bin/elasticsearch-keystore add --stdin s3.client.default.secret_key
+
+# credentials for AWS EC2 discovery plugin
+echo ${AWS_ACCESS_KEY_ID} | bin/elasticsearch-keystore add --stdin discovery.ec2.access_key
+echo ${AWS_SECRET_KEY} | bin/elasticsearch-keystore add --stdin discovery.ec2.secret_key
+
+# sudo su
+# ulimit -n 65536
+# su elasticsearchb
+
+/usr/local/bin/docker-entrypoint.sh
+
+exec "$@"

--- a/eb/default/.ebextensions/04-max-map-count.config
+++ b/eb/default/.ebextensions/04-max-map-count.config
@@ -5,3 +5,7 @@ files:
     group: root
     content: |
       vm.max_map_count = 262144
+
+commands:
+  01-enable-max-map-count:
+    command: sysctl --system

--- a/eb/default/.ebextensions/04-max-map-count.config
+++ b/eb/default/.ebextensions/04-max-map-count.config
@@ -1,11 +1,5 @@
-files:
-  "/etc/sysctl.d/01-max-map-count.conf":
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      vm.max_map_count = 262144
-
 commands:
   01-enable-max-map-count:
-    command: sysctl --system
+    command: |
+      sudo su
+      sysctl -w vm.max_map_count=262144

--- a/eb/default/.ebextensions/04-max-map-count.config
+++ b/eb/default/.ebextensions/04-max-map-count.config
@@ -1,5 +1,4 @@
 commands:
   01-enable-max-map-count:
-    command: |
-      sudo su
+    command:
       sysctl -w vm.max_map_count=262144

--- a/eb/default/.ebextensions/06-file-descriptors.config
+++ b/eb/default/.ebextensions/06-file-descriptors.config
@@ -1,0 +1,5 @@
+commands:
+  01-update-ulimit:
+    command: |
+      sudo su
+      sed -i -e 's/1024:4096/65536:65536/g' /etc/sysconfig/docker

--- a/eb/default/.ebextensions/06-file-descriptors.config
+++ b/eb/default/.ebextensions/06-file-descriptors.config
@@ -1,5 +1,4 @@
 commands:
   01-update-ulimit:
-    command: |
-      sudo su
+    command:
       sed -i -e 's/1024:4096/65536:65536/g' /etc/sysconfig/docker

--- a/eb/indexer/.ebextensions/04-max-map-count.config
+++ b/eb/indexer/.ebextensions/04-max-map-count.config
@@ -5,3 +5,7 @@ files:
     group: root
     content: |
       vm.max_map_count = 262144
+
+commands:
+  01-enable-max-map-count:
+    command: sysctl --system

--- a/eb/indexer/.ebextensions/04-max-map-count.config
+++ b/eb/indexer/.ebextensions/04-max-map-count.config
@@ -1,11 +1,5 @@
-files:
-  "/etc/sysctl.d/01-max-map-count.conf":
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      vm.max_map_count = 262144
-
 commands:
   01-enable-max-map-count:
-    command: sysctl --system
+    command: |
+      sudo su
+      sysctl -w vm.max_map_count=262144

--- a/eb/indexer/.ebextensions/04-max-map-count.config
+++ b/eb/indexer/.ebextensions/04-max-map-count.config
@@ -1,5 +1,4 @@
 commands:
   01-enable-max-map-count:
-    command: |
-      sudo su
+    command:
       sysctl -w vm.max_map_count=262144

--- a/eb/indexer/.ebextensions/06-file-descriptors.config
+++ b/eb/indexer/.ebextensions/06-file-descriptors.config
@@ -1,0 +1,5 @@
+commands:
+  01-update-ulimit:
+    command: |
+      sudo su
+      sed -i -e 's/1024:4096/65536:65536/g' /etc/sysconfig/docker

--- a/eb/indexer/.ebextensions/06-file-descriptors.config
+++ b/eb/indexer/.ebextensions/06-file-descriptors.config
@@ -1,5 +1,4 @@
 commands:
   01-update-ulimit:
-    command: |
-      sudo su
+    command:
       sed -i -e 's/1024:4096/65536:65536/g' /etc/sysconfig/docker

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -67,6 +67,19 @@
             "memory": 2048
 	},
         {
+            "name": "kibana",
+            "image": "docker.elastic.co/kibana/kibana:6.6.1",
+            "essential": true,
+            "links": ["elasticsearch"],
+            "portMappings": [
+                {
+                    "hostPort": 5601,
+                    "containerPort": 5601
+                }
+            ],
+            "memoryReservation": 128
+        },
+        {
             "name": "search-indexer",
             "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:0.2.19",
             "essential": false,

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -144,6 +144,10 @@
         (do
           ;; add jobs to scheduler in sequence
 
+          (let [eids (get-eids-by-type db :gene/id)
+                jobs (make-batches 100 :gene eids)]  ; smaller batch for slower ones
+            (doseq [job jobs]
+              (>!! scheduler job)))
           (let [eids (get-eids-by-type db :analysis/id)
                 jobs (make-batches 1000 :analysis eids)]
             (doseq [job jobs]
@@ -186,10 +190,6 @@
               (>!! scheduler job)))
           (let [eids (get-eids-by-type db :feature/id)
                 jobs (make-batches 1000 :feature eids)]
-            (doseq [job jobs]
-              (>!! scheduler job)))
-          (let [eids (get-eids-by-type db :gene/id)
-                jobs (make-batches 100 :gene eids)]  ; smaller batch for slower ones
             (doseq [job jobs]
               (>!! scheduler job)))
           (let [eids (get-eids-by-type db :gene-class/id)

--- a/src/wb_es/datomic/data/gene.clj
+++ b/src/wb_es/datomic/data/gene.clj
@@ -14,15 +14,14 @@
                                     (map :gene.other-name/text))
                                (:gene/molecular-name entity))
                        (cons (:gene/sequence-name entity)))
-     :description (or
-                   (->> entity
+     :description (->> entity
                         (:gene/automated-description)
                         (first)
                         (:gene.automated-description/text))
-                   (->> entity
+     :legacy_description (->> entity
                         (:gene/concise-description)
                         (first)
-                        (:gene.concise-description/text)))
+                        (:gene.concise-description/text))
      :species (data-util/format-entity-species :gene/species entity)
      :allele (->> entity
                   (:variation.gene/_gene)

--- a/src/wb_es/datomic/data/util.clj
+++ b/src/wb_es/datomic/data/util.clj
@@ -22,7 +22,7 @@
 (defn default-metadata
   "default implementation of the data method of Document protocol"
   [entity]
-  {:_type "generic"
+  {:_type "_doc"
    :_id (:db/id entity)})
 
 (defn format-enum

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -47,6 +47,8 @@
     :description_all {:type "text"}
     :description {:type "text"
                   :copy_to "description_all"}
+    :legacy_description {:type "text"
+                         :copy_to "description_all"}
 
     :genotype {:type "text"}
 

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -44,6 +44,10 @@
                      :normalizer "lowercase_normalizer"}
                :name {:type "text"}}}
 
+    :description_all {:type "text"}
+    :description {:type "text"
+                  :copy_to "description_all"}
+
     :genotype {:type "text"}
 
     ;; start of refs

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -5,51 +5,46 @@
 
 (defn ref-mapping []
   {:type "nested"
-   :properties {:id {:type "string"
-                     :analyzer "keyword"}
-                :label {:type "string"}
-                :class {:type "string"}}})
+   :properties {:id {:type "keyword"}
+                :label {:type "text"}
+                :class {:type "keyword"}}})
 
 (def generic-mapping
   {:properties
-   {:wbid {:type "string"
-           :analyzer "keyword_ignore_case"
-           :include_in_all false
-           :fields {:autocomplete_keyword {:type "string"
-                                           :analyzer "autocomplete"
-                                           :search_analyzer "keyword_ignore_case"}}}
+   {:wbid {:type "keyword"
+           :normalizer "lowercase_normalizer"
+           :fields {:autocomplete_keyword {:type "text"
+                                           :analyzer "autocomplete_keyword"
+                                           :search_analyzer "keyword_ignore_case"
+                                           }}
+           }
 
-    :label {:type "string"
-            :include_in_all false
-            :fields {:raw {:type "string"
-                           :analyzer "keyword_ignore_case"}
-                     :autocomplete {:type "string"
+    :label {:type "text"
+            :fields {:raw {:type "keyword"}
+                     :autocomplete {:type "text"
                                     :analyzer "autocomplete"
                                     :search_analyzer "standard"}
 
                      ;; autocomplete analyzer will handle gene name like unc-22 as phase search,
                      ;; seeems sufficient for now, no need for autocomplete_keyword analyzer
-                     :autocomplete_keyword {:type "string"
+                     :autocomplete_keyword {:type "text"
                                             :analyzer "autocomplete_keyword"
                                             :search_analyzer "keyword_ignore_case"}
                      }
             }
-    :other_unique_ids {:type "string"
-                       :analyzer "keyword_ignore_case"
-                       :include_in_all false}
-    :other_names {:type "string"
-                  :include_in_all false
-                  :analyzer "keyword_ignore_case"}
-    :page_type {:type "string"
-                :analyzer "keyword_ignore_case"}
-    :paper_type {:type "string"
-                 :analyzer "keyword_ignore_case"}
+    :other_unique_ids {:type "keyword"
+                       :normalizer "lowercase_normalizer"}
+    :other_names {:type "text"}
+    :page_type {:type "keyword"
+                :normalizer "lowercase_normalizer"}
+    :paper_type {:type "keyword"
+                 :normalizer "lowercase_normalizer"}
     :species {:properties
-              {:key {:type "string"
-                     :analyzer "keyword_ignore_case"}
-               :name {:type "string"}}}
+              {:key {:type "keyword"
+                     :normalizer "lowercase_normalizer"}
+               :name {:type "text"}}}
 
-    :genotype {:type "string"}
+    :genotype {:type "text"}
 
     ;; start of refs
     :allele (ref-mapping)
@@ -65,6 +60,9 @@
    {:analysis {:filter {"autocomplete_filter" {:type "edge_ngram"
                                                :min_gram 2
                                                :max_gram 20}}
+               :normalizer {"lowercase_normalizer" {:type "custom"
+                                                    :char_filter []
+                                                    :filter ["lowercase"]}}
                :analyzer {"autocomplete" {:type "custom"
                                           :tokenizer "standard"
                                           :filter ["lowercase" "autocomplete_filter"]}
@@ -74,7 +72,11 @@
                           "keyword_ignore_case" {:type "custom"
                                                  :tokenizer "keyword"
                                                  :filter ["lowercase"]}}}}
-   :mappings {:generic generic-mapping}})
+   :mappings {:_default_ default-mapping
+              :generic {}
+              ;; :interaction_group {}
+              ;; :interaction {:_parent {:type "interaction_group"}}
+              }})
 
 (defn create-index
   ([index & {:keys [default-index delete-existing]}]

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -40,7 +40,8 @@
 
     ;; start of copy_to fields
     :description_all {:type "text"}
-    :other {:type "text"}
+    :other {:type "text"
+            :analyzer "split_underscore_analyzer"}
     ;; end of copy to fields
 
 
@@ -95,7 +96,10 @@
                                                   :filter ["lowercase" "autocomplete_filter"]}
                           "keyword_ignore_case" {:type "custom"
                                                  :tokenizer "keyword"
-                                                 :filter ["lowercase"]}}}}
+                                                 :filter ["lowercase"]}
+                          "split_underscore_analyzer"
+                          {:char_filter ["replace_underscore"]
+                           :tokenizer "standard"}}}}
    :mappings {:_doc generic-mapping}})
 
 (defn create-index

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -39,9 +39,11 @@
 
 
     ;; start of copy_to fields
-    :description_all {:type "text"}
-    :other {:type "text"
-            :analyzer "split_underscore_analyzer"}
+    :categories_all {:type "text"
+                     :analyzer "split_underscore_analyzer"}
+    :description_all {:type "text"
+                      :store true}
+    :other {:type "text"}
     ;; end of copy to fields
 
 
@@ -51,17 +53,17 @@
                          :copy_to "description_all"}
 
     :page_type {:type "keyword"
-                :copy_to "other"
+                :copy_to "categories_all"
                 :normalizer "lowercase_normalizer"}
     :paper_type {:type "keyword"
-                 :copy_to "other"
+                 :copy_to "categories_all"
                  :normalizer "lowercase_normalizer"}
     :species {:properties
               {:key {:type "keyword"
-                     :copy_to "other"
+                     :copy_to "categories_all"
                      :normalizer "lowercase_normalizer"}
                :name {:type "text"
-                      :copy_to "other"}}}
+                      :copy_to "categories_all"}}}
 
     :genotype {:type "text"
                :copy_to "other"}

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -72,11 +72,7 @@
                           "keyword_ignore_case" {:type "custom"
                                                  :tokenizer "keyword"
                                                  :filter ["lowercase"]}}}}
-   :mappings {:_default_ default-mapping
-              :generic {}
-              ;; :interaction_group {}
-              ;; :interaction {:_parent {:type "interaction_group"}}
-              }})
+   :mappings {:_doc generic-mapping}})
 
 (defn create-index
   ([index & {:keys [default-index delete-existing]}]

--- a/src/wb_es/mappings/core.clj
+++ b/src/wb_es/mappings/core.clj
@@ -6,7 +6,8 @@
 (defn ref-mapping []
   {:type "nested"
    :properties {:id {:type "keyword"}
-                :label {:type "text"}
+                :label {:type "text"
+                        :copy_to "other"}
                 :class {:type "keyword"}}})
 
 (def generic-mapping
@@ -35,22 +36,34 @@
     :other_unique_ids {:type "keyword"
                        :normalizer "lowercase_normalizer"}
     :other_names {:type "text"}
-    :page_type {:type "keyword"
-                :normalizer "lowercase_normalizer"}
-    :paper_type {:type "keyword"
-                 :normalizer "lowercase_normalizer"}
-    :species {:properties
-              {:key {:type "keyword"
-                     :normalizer "lowercase_normalizer"}
-               :name {:type "text"}}}
 
+
+    ;; start of copy_to fields
     :description_all {:type "text"}
+    :other {:type "text"}
+    ;; end of copy to fields
+
+
     :description {:type "text"
                   :copy_to "description_all"}
     :legacy_description {:type "text"
                          :copy_to "description_all"}
 
-    :genotype {:type "text"}
+    :page_type {:type "keyword"
+                :copy_to "other"
+                :normalizer "lowercase_normalizer"}
+    :paper_type {:type "keyword"
+                 :copy_to "other"
+                 :normalizer "lowercase_normalizer"}
+    :species {:properties
+              {:key {:type "keyword"
+                     :copy_to "other"
+                     :normalizer "lowercase_normalizer"}
+               :name {:type "text"
+                      :copy_to "other"}}}
+
+    :genotype {:type "text"
+               :copy_to "other"}
 
     ;; start of refs
     :allele (ref-mapping)
@@ -69,6 +82,11 @@
                :normalizer {"lowercase_normalizer" {:type "custom"
                                                     :char_filter []
                                                     :filter ["lowercase"]}}
+               :char_filter
+               {"replace_underscore"
+                {:type "mapping"
+                 :mappings ["_ => -"]}}
+
                :analyzer {"autocomplete" {:type "custom"
                                           :tokenizer "standard"
                                           :filter ["lowercase" "autocomplete_filter"]}

--- a/src/wb_es/web/core.clj
+++ b/src/wb_es/web/core.clj
@@ -38,7 +38,7 @@
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
                                         {:match_phrase {:description_all {:query q
-                                                                          :boost 0.2}}}
+                                                                          :boost 0.1}}}
                                         {:match_phrase {:other {:query q
                                                                 :boost 0.1}}}
                                         ]
@@ -137,7 +137,7 @@
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
                                         {:match_phrase {:description_all {:query q
-                                                                          :boost 0.2}}}
+                                                                          :boost 0.1}}}
                                         {:match_phrase {:other {:query q
                                                                 :boost 0.1}}}]
                               :tie_breaker 0.3}

--- a/src/wb_es/web/core.clj
+++ b/src/wb_es/web/core.clj
@@ -37,8 +37,8 @@
                                         {:match_phrase {:label {:query q}}}
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
-                                        {:match_phrase {:_all {:query q
-                                                               :boost 0.1}}}]
+                                        {:match_phrase {:description_all {:query q
+                                                                          :boost 0.1}}}]
                               :tie_breaker 0.3}}
                             ]}}
                    :highlight
@@ -133,8 +133,8 @@
                                         {:match_phrase {:label {:query q}}}
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
-                                        {:match_phrase {:_all {:query q
-                                                               :boost 0.1}}}]
+                                        {:match_phrase {:description_all {:query q
+                                                                          :boost 0.1}}}]
                               :tie_breaker 0.3}
                              }]}}}
                   {:query {:bool {:filter (get-filter options)}}})

--- a/src/wb_es/web/core.clj
+++ b/src/wb_es/web/core.clj
@@ -38,7 +38,10 @@
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
                                         {:match_phrase {:description_all {:query q
-                                                                          :boost 0.1}}}]
+                                                                          :boost 0.2}}}
+                                        {:match_phrase {:other {:query q
+                                                                :boost 0.1}}}
+                                        ]
                               :tie_breaker 0.3}}
                             ]}}
                    :highlight
@@ -134,7 +137,9 @@
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
                                         {:match_phrase {:description_all {:query q
-                                                                          :boost 0.1}}}]
+                                                                          :boost 0.2}}}
+                                        {:match_phrase {:other {:query q
+                                                                :boost 0.1}}}]
                               :tie_breaker 0.3}
                              }]}}}
                   {:query {:bool {:filter (get-filter options)}}})

--- a/src/wb_es/web/core.clj
+++ b/src/wb_es/web/core.clj
@@ -28,43 +28,46 @@
     (let [query (if (and q (not= (clojure.string/trim q) ""))
                   {;:explain true
                    :sort [:_score
-                          {:label {:order :asc}}]
+                          {:label.raw {:order :asc}}]
                    :query
                    {:bool
                     {:must [{:bool {:filter (get-filter options)}}
                             {:dis_max
                              {:queries [{:term {:wbid q}}
-                                        {:match_phrase {:label {:query q
-                                                                :minimum_should_match "70%"}}}
+                                        {:match_phrase {:label {:query q}}}
                                         {:match_phrase {:other_names {:query q
-                                                                      :minimum_should_match "70%"
                                                                       :boost 0.9}}}
                                         {:match_phrase {:_all {:query q
-                                                               :minimum_should_match "70%"
                                                                :boost 0.1}}}]
-                              :tie_breaker 0.3}}]}}
+                              :tie_breaker 0.3}}
+                            ]}}
                    :highlight
                    {:fields {:wbid {}
                              :wbid_as_label {}
                              :label {}
                              :other_names {}
-                             :description {}}}}
+                             :description {}}}
+                   }
                   {:query {:bool {:filter (get-filter options)}}})
 
           response
-          (http/get (format "%s/%s/_search?size=%s&from=%s"
-                            es-base-url
-                            index
-                            (get options :size 10)
-                            (get options :from 0))
-                    {:content-type "application/json"
-                     :body (json/generate-string query)})]
+          (try
+            (http/get (format "%s/%s/_search?size=%s&from=%s"
+                              es-base-url
+                              index
+                              (get options :size 10)
+                              (get options :from 0))
+                      {:content-type "application/json"
+                       :body (json/generate-string query)})
+            (catch clojure.lang.ExceptionInfo e
+              (clojure.pprint/pprint (ex-data e))
+              (throw e)))]
       (json/parse-string (:body response) true))))
 
 
 (defn autocomplete [es-base-url index q options]
   (let [query {:sort [:_score
-                      {:label {:order :asc}}]
+                      {:label.raw {:order :asc}}]
                :query
                {:bool
                 {:must [{:bool {:filter (get-filter options)}}
@@ -127,15 +130,13 @@
                     {:must [{:bool {:filter (get-filter options)}}
                             {:dis_max
                              {:queries [{:term {:wbid q}}
-                                        {:match_phrase {:label {:query q
-                                                                :minimum_should_match "70%"}}}
+                                        {:match_phrase {:label {:query q}}}
                                         {:match_phrase {:other_names {:query q
-                                                                      :minimum_should_match "70%"
                                                                       :boost 0.9}}}
                                         {:match_phrase {:_all {:query q
-                                                               :minimum_should_match "70%"
                                                                :boost 0.1}}}]
-                              :tie_breaker 0.3}}]}}}
+                              :tie_breaker 0.3}
+                             }]}}}
                   {:query {:bool {:filter (get-filter options)}}})
 
           response

--- a/src/wb_es/web/core.clj
+++ b/src/wb_es/web/core.clj
@@ -37,8 +37,10 @@
                                         {:match_phrase {:label {:query q}}}
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
+                                        {:match_phrase {:categories_all {:query q
+                                                                         :boost 0.9}}}
                                         {:match_phrase {:description_all {:query q
-                                                                          :boost 0.1}}}
+                                                                          :boost 0.2}}}
                                         {:match_phrase {:other {:query q
                                                                 :boost 0.1}}}
                                         ]
@@ -136,8 +138,10 @@
                                         {:match_phrase {:label {:query q}}}
                                         {:match_phrase {:other_names {:query q
                                                                       :boost 0.9}}}
+                                        {:match_phrase {:categories_all {:query q
+                                                                         :boost 0.9}}}
                                         {:match_phrase {:description_all {:query q
-                                                                          :boost 0.1}}}
+                                                                          :boost 0.2}}}
                                         {:match_phrase {:other {:query q
                                                                 :boost 0.1}}}]
                               :tie_breaker 0.3}

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -245,8 +245,10 @@
       (do
         (index-datomic-entity (d/entity db [:gene/id "WBGene00006741"]))
         (testing "search automated description"
-          (is (has-hit (search "STOM") "WBGene00006741"))))
-      )))
+          (is (has-hit (search "STOM") "WBGene00006741")))
+        (testing "search legacy manual description"
+          (is (has-hit (search "SLPs") "WBGene00006741")))
+        ))))
 
 (deftest go-term-type-test
   (testing "go-term with creatine biosynthetic process as example"

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -174,6 +174,21 @@
                         hits)))
 
             )))
+
+      (testing "search by some word from the full name"
+        (let [hits (-> (search "parkinson")
+                       (get-in [:hits :hits]))]
+          (is (some (fn [hit]
+                      (= "Parkinson's disease"
+                         (get-in hit [:_source :label])))
+                    hits)))
+        (let [hits (-> (search "early onset parkinson")
+                       (get-in [:hits :hits]))]
+          (is (some (fn [hit]
+                      (= "early-onset Parkinson's disease"
+                         (get-in hit [:_source :label])))
+                    hits))))
+
       (testing "search by do-term synonym"
         (apply index-datomic-entity disease-parks)
         (let [hits (-> (search "paralysis agitans")

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -250,6 +250,14 @@
           (is (has-hit (search "SLPs") "WBGene00006741")))
         ))))
 
+(deftest gene-type-species-test
+  (testing "species of gene"
+    (let [db (d/db datomic-conn)]
+      (do
+        (index-datomic-entity (d/entity db [:gene/id "WBGene00030670"]))
+        (testing "species name in search string"
+          (is (has-hit (search "C. briggsae") "WBGene00030670")))))))
+
 (deftest go-term-type-test
   (testing "go-term with creatine biosynthetic process as example"
     (let [db (d/db datomic-conn)]

--- a/test/wb_es/core_test.clj
+++ b/test/wb_es/core_test.clj
@@ -233,6 +233,21 @@
           (is (has-gene-hit (search "CELE_Y54G11A.10") "WBGene00002996"))))
       )))
 
+(defn- has-hit [result id]
+  (->> (get-in result [:hits :hits])
+       (some (fn [hit]
+               (= id
+                  (get-in hit [:_source :wbid]))))))
+
+(deftest gene-type-description-test
+  (testing "gene descriptions"
+    (let [db (d/db datomic-conn)]
+      (do
+        (index-datomic-entity (d/entity db [:gene/id "WBGene00006741"]))
+        (testing "search automated description"
+          (is (has-hit (search "STOM") "WBGene00006741"))))
+      )))
+
 (deftest go-term-type-test
   (testing "go-term with creatine biosynthetic process as example"
     (let [db (d/db datomic-conn)]


### PR DESCRIPTION
- create and deploy containers with AWS and S3 repository plugin
- include Kibana in the stack
- fix breaking changes, such the deprecation of `_all` field, and the deprecation of multiple types within the same index