### PR TITLE
Use role instead of access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Ensure the environment variables above are set appropriately before preceeding.
 
 To make a production-like environment locally, `(cd eb/default/ && make eb-local-run)`.
 
+**Troubleshooot tip:**
+- If `ERROR: InvalidProfileError - The config profile (eb-cli) could not be found` occurs while running on the development server instance, running `eb init` in the appropriate directory, ie. `eb/indexer/` or `eb/default`, seems to fix that. Remember that instance profile rather than user profile is used on the development server instance.
+
 ### Deploy Hotfix
 
 Critical bug fixes are sometimes applied outside of the schedule releases to the production environment.

--- a/README.md
+++ b/README.md
@@ -30,17 +30,23 @@ You will need to **install**:
 - AWS CLI
 - Elastic Beanstalk CLI
 
-You will need to obtain various **AWS permissions** for:
+You will need to set the following environment variables:
+
+- WB_DB_URI (required)
+
+Optional environment variables:
+- AWS_ACCESS_KEY_ID (for local/Non-AWS dev environment only)
+- AWS_SECRET_ACCESS_KEY (for local/Non-AWS dev environment only)
+
+For development, appropriate AWS permission is setup on the development server instance through an [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html). The permissions are granted to the role `wb-web-team-dev-instance-role` that is attached to the development server instance.
+
+For production, the instance profile role `wb-search-beanstalk-ec2-role` is used by instances created by Beanstalk.
+
+The permissions being granted include:
 - S3 bucket wormbase-elasticsearch-snapshots
 - WormBase Datomic/DynamoDB database
 - Elastic Beanstalk / Starting and stopping EC2
 
-Sensitive info are communicated to the programs through **environment variables**.
-You will need to set the following environment variables:
-
-- AWS_ACCESS_KEY_ID
-- AWS_SECRET_ACCESS_KEY
-- WB_DB_URI
 
 ## Production environment
 

--- a/docker/es-entrypoint.sh
+++ b/docker/es-entrypoint.sh
@@ -1,15 +1,21 @@
 #!/bin/sh
 set -e
 
-bin/elasticsearch-keystore create
+# If access key isn't provided, defaults to instance profile/role.
+# Access key is probably only useful if developing locally, ie not on AWS ec2
+if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_KEY}" ]; then
 
-# credentials for AWS S3 repository plugin
-echo ${AWS_ACCESS_KEY_ID} | bin/elasticsearch-keystore add --stdin s3.client.default.access_key
-echo ${AWS_SECRET_KEY} | bin/elasticsearch-keystore add --stdin s3.client.default.secret_key
+    bin/elasticsearch-keystore create
 
-# credentials for AWS EC2 discovery plugin
-echo ${AWS_ACCESS_KEY_ID} | bin/elasticsearch-keystore add --stdin discovery.ec2.access_key
-echo ${AWS_SECRET_KEY} | bin/elasticsearch-keystore add --stdin discovery.ec2.secret_key
+    # credentials for AWS S3 repository plugin
+    echo ${AWS_ACCESS_KEY_ID} | bin/elasticsearch-keystore add --stdin s3.client.default.access_key
+    echo ${AWS_SECRET_KEY} | bin/elasticsearch-keystore add --stdin s3.client.default.secret_key
+
+    # credentials for AWS EC2 discovery plugin
+    echo ${AWS_ACCESS_KEY_ID} | bin/elasticsearch-keystore add --stdin discovery.ec2.access_key
+    echo ${AWS_SECRET_KEY} | bin/elasticsearch-keystore add --stdin discovery.ec2.secret_key
+
+fi
 
 # sudo su
 # ulimit -n 65536

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:1.0.4",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.0.0",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:1.0.4",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.0.0",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.0.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.0.0-alpha2",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.0.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.0.0-alpha2",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Makefile
+++ b/eb/default/Makefile
@@ -9,12 +9,12 @@ eb-local-run:
 
 .PHONY: eb-setenv
 eb-setenv:
-	@eb setenv AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY} WB_DB_URI=${WB_DB_URI} RESTORE_FROM_SNAPSHOT=${RESTORE_FROM_SNAPSHOT}
+	@eb setenv WB_DB_URI=${WB_DB_URI} RESTORE_FROM_SNAPSHOT=${RESTORE_FROM_SNAPSHOT}
 
 .PHONY: eb-create
 eb-create:
-	@eb create wormbase-search-${LOWER_WS_VERSION}-${ENV_NAME_SUFFIX} --cfg v0.2.14 --cname wormbase-search-${LOWER_WS_VERSION} --envvars AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID},AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY},WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=${RESTORE_FROM_SNAPSHOT}
+	@eb create wormbase-search-${LOWER_WS_VERSION}-${ENV_NAME_SUFFIX} --cfg v1.0.0 --cname wormbase-search-${LOWER_WS_VERSION} --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=${RESTORE_FROM_SNAPSHOT}
 
 .PHONY: eb-create-hotfix
 eb-create-hotfix:
-	@eb create wormbase-search-${LOWER_WS_VERSION}-${ENV_NAME_SUFFIX} --cfg v0.2.14 --cname wormbase-search-hotfix --envvars AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID},AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY},WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=${RESTORE_FROM_SNAPSHOT}
+	@eb create wormbase-search-${LOWER_WS_VERSION}-${ENV_NAME_SUFFIX} --cfg v1.0.0 --cname wormbase-search-hotfix --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=${RESTORE_FROM_SNAPSHOT}

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.0.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.0.0-alpha2",
             "essential": true,
             "portMappings": [
                 {
@@ -36,7 +36,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.0.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.0.0-alpha2",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -81,7 +81,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.0.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.0.0-alpha2",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:1.0.4",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.0.0",
             "essential": true,
             "portMappings": [
                 {
@@ -36,7 +36,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:1.0.4",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.0.0",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -81,7 +81,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:1.0.4",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.0.0",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Makefile
+++ b/eb/indexer/Makefile
@@ -1,7 +1,7 @@
 .PHONY: eb-setenv
 eb-setenv:
-	@eb setenv AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY} WB_DB_URI=${WB_DB_URI} RESTORE_FROM_SNAPSHOT=
+	@eb setenv WB_DB_URI=${WB_DB_URI} RESTORE_FROM_SNAPSHOT=
 
 .PHONY: eb-create
 eb-create:
-	@eb create wormbase-search-indexer --cfg v0.2.9 --cname wormbase-search-indexer --envvars AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID},AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY},WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=
+	@eb create wormbase-search-indexer --cfg v1.0.0 --cname wormbase-search-indexer --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=

--- a/eb/indexer/Makefile
+++ b/eb/indexer/Makefile
@@ -4,4 +4,4 @@ eb-setenv:
 
 .PHONY: eb-create
 eb-create:
-	@eb create wormbase-search-indexer --cfg v1.0.0 --cname wormbase-search-indexer --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=
+	@eb create wormbase-search-indexer --cfg v1 --cname wormbase-search-indexer --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.0.0-alpha2"
+(defproject wb-es "2.0.0-alpha3-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.0.0-alpha1-SNAPSHOT"
+(defproject wb-es "2.0.0-alpha2-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.0.0-alpha2-SNAPSHOT"
+(defproject wb-es "2.0.0-alpha2"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.0.0"
+(defproject wb-es "2.0.0-alpha1-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.0.0-SNAPSHOT"
+(defproject wb-es "2.0.0"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "1.0.5-SNAPSHOT"
+(defproject wb-es "2.0.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"


### PR DESCRIPTION
Use IAM role through ec2 instance profile to obtain AWS permission for both development and production, while retain the capability to use access keys to gain permission, for example when developing locally, outside of AWS.

Benefits:
- Access keys can be deactivated more easily (at short notice) when it's not tied with production deployment
- Anyone using the dev instance will no longer require individual permission, as permission is granted to the instance (through role and instance profile)