### PR TITLE
Fixes missed items by the search indexer

### DIFF
--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.1",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.1",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.3",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.4",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.3",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.4",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.5",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.6",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.5",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.6",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.1",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.2",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.1",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.2",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.1.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.2.0",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.1.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.2.0",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.2.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.0",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.2.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.0",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.2",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.3",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.2",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.3",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/default/Dockerrun.aws.json
+++ b/eb/default/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.4",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.5",
             "essential": true,
             "portMappings": [
                 {
@@ -40,7 +40,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.4",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.5",
 	    "essential": true,
 	    "portMappings": [
 		{

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.4",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.5",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.4",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.5",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.4",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.5",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.2.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.0",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.2.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.0",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.2.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.0",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.1",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.2",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.1",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.2",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.1",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.2",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.2",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.3",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.2",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.3",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.2",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.3",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.1",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.1",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.1",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -17,7 +17,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.1.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.2.0",
             "essential": true,
             "portMappings": [
                 {
@@ -36,7 +36,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.1.0",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.2.0",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -81,7 +81,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.1.0",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.2.0",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -7,6 +7,12 @@
 		"sourcePath": "/var/lib/elasticsearch/data"
 	    }
 	},
+	{
+	    "name": "indexing-job-queue-volume",
+	    "host": {
+		"sourcePath": "/tmp/indexer-queue"
+	    }
+	},
         {
             "name": "nginx-proxy-conf",
             "host": {
@@ -94,6 +100,12 @@
 		    "value": "-Xms8000m -Xmx11264m"
 		}
 	    ],
+            "mountPoints": [
+                {
+                    "sourceVolume": "indexing-job-queue-volume",
+                    "containerPath": "/tmp/indexer-queue"
+                }
+            ],
 	    "memory": 12288
         },
         {

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.5",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.6",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.5",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.6",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.5",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.6",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Dockerrun.aws.json
+++ b/eb/indexer/Dockerrun.aws.json
@@ -23,7 +23,7 @@
     "containerDefinitions": [
         {
             "name": "search-web-api",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.3",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-web-api:2.3.4",
             "essential": true,
             "portMappings": [
                 {
@@ -42,7 +42,7 @@
         },
 	{
 	    "name": "elasticsearch",
-	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.3",
+	    "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/aws-elasticsearch:2.3.4",
 	    "essential": true,
 	    "portMappings": [
 		{
@@ -87,7 +87,7 @@
         },
         {
             "name": "search-indexer",
-            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.3",
+            "image": "357210185381.dkr.ecr.us-east-1.amazonaws.com/wormbase/search-indexer:2.3.4",
             "essential": false,
 	    "links": ["elasticsearch"],
 	    "environment": [

--- a/eb/indexer/Makefile
+++ b/eb/indexer/Makefile
@@ -4,4 +4,4 @@ eb-setenv:
 
 .PHONY: eb-create
 eb-create:
-	@eb create wormbase-search-indexer --cfg v1 --cname wormbase-search-indexer --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=
+	@eb create wormbase-search-indexer --cfg v2-indexer --cname wormbase-search-indexer --envvars WB_DB_URI=${WB_DB_URI},RESTORE_FROM_SNAPSHOT=

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.2.0-SNAPSHOT"
+(defproject wb-es "2.2.0"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.1-SNAPSHOT"
+(defproject wb-es "2.3.1"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
    [environ "1.1.0"]
    [mount "0.1.11"]
    [org.clojure/clojure "1.8.0"]
+   [factual/durable-queue "0.1.5"]
 
    ;; the following dependecies are only needed for web
    [compojure "1.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.3-SNAPSHOT"
+(defproject wb-es "2.3.3"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.5-SNAPSHOT"
+(defproject wb-es "2.3.5"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.0"
+(defproject wb-es "2.3.1-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.1"
+(defproject wb-es "2.3.2-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.2-SNAPSHOT"
+(defproject wb-es "2.3.2"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.4"
+(defproject wb-es "2.3.5-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.6-SNAPSHOT"
+(defproject wb-es "2.3.6"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
    [mount "0.1.11"]
    [org.clojure/clojure "1.8.0"]
    [factual/durable-queue "0.1.5"]
+   [com.taoensso/timbre "4.10.0"]
 
    ;; the following dependecies are only needed for web
    [compojure "1.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.6"
+(defproject wb-es "2.3.7-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.2"
+(defproject wb-es "2.3.3-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.3"
+(defproject wb-es "2.3.4-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.0-SNAPSHOT"
+(defproject wb-es "2.3.0"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.1.1-SNAPSHOT"
+(defproject wb-es "2.2.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.5"
+(defproject wb-es "2.3.6-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.3.4-SNAPSHOT"
+(defproject wb-es "2.3.4"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wb-es "2.2.0"
+(defproject wb-es "2.3.0-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :min-lein-version "2.7.0"

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -137,15 +137,10 @@
 
 (defn schedule-jobs-sample [db]
   ;; schedule something for testing
-  ;; (let [eids (get-eids-by-type db :analysis/id)
-  ;;       jobs (make-batches 1000 :analysis eids)]
-  ;;   (doseq [job jobs]
-  ;;     (scheduler-put! job)))
-  (let [eids (get-eids-by-type db :variation/id)
-        jobs (make-batches 1000 :variation eids)]
+  (let [eids (get-eids-by-type db :analysis/id)
+        jobs (make-batches 1000 :analysis eids)]
     (doseq [job jobs]
       (scheduler-put! job)))
-
   )
 
 (defn schedule-jobs-all [db]
@@ -389,7 +384,7 @@
                     :delete-existing true)
       (let [db (d/db datomic-conn)]
         (do
-          (schedule-jobs-sample db)
+          (schedule-jobs-all db)
           (connect-snapshot-repository repository-name)
           (scheduler-put! (with-meta {} {:action "snapshot"
                                          :index index-id

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -67,7 +67,9 @@
                      (let [status (:status body)]
                        (cond
                         (< status 300) (update result :success inc)
-                        :else (update result :error inc))))
+                        :else (do
+                                (error body)
+                                (update result :error inc)))))
                    {:success 0 :error 0})
            ))))
 

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -112,7 +112,7 @@
 (defn- scheduler-retry! [& args] (apply dq/retry! args))
 
 
-(defn run [& {:keys [db index-revision-number index-id]
+(defn run [& {:keys [db index-revision-number index-id skip-create-snapshot]
               :or {db (d/db datomic-conn)
                    index-revision-number 0
                    index-id (format "%s_v%s" release-id index-revision-number)}}]
@@ -335,11 +335,12 @@
           )
         )
 
-      (let [repository-name "s3_repository"]
-        (do
-          (connect-snapshot-repository repository-name)
-          (let [snapshot-id (get-next-snapshot-id repository-name release-id)]
-            (save-snapshot index-id repository-name snapshot-id))))
+      (if-not skip-create-snapshot
+        (let [repository-name "s3_repository"]
+          (do
+            (connect-snapshot-repository repository-name)
+            (let [snapshot-id (get-next-snapshot-id repository-name release-id)]
+              (save-snapshot index-id repository-name snapshot-id)))))
       )))
 
 

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -316,7 +316,7 @@
       (doseq [job jobs]
         (scheduler-put! job)))
     (let [eids (get-eids-by-type db :variation/id)
-          jobs (make-batches 100 :variation eids)] ; smaller batch for slower ones
+          jobs (make-batches 1000 :variation eids)]
       (doseq [job jobs]
         (scheduler-put! job)))
 
@@ -390,7 +390,7 @@
                                          :index index-id
                                          :repository repository-name}))
           (->> (partial worker db)
-               (repeatedly 4)
+               (repeatedly 5)
                (pmap deref) ; wait for the futures to return
                (doall) ; force the side effects
                )

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -137,10 +137,15 @@
 
 (defn schedule-jobs-sample [db]
   ;; schedule something for testing
-  (let [eids (get-eids-by-type db :analysis/id)
-        jobs (make-batches 1000 :analysis eids)]
+  ;; (let [eids (get-eids-by-type db :analysis/id)
+  ;;       jobs (make-batches 1000 :analysis eids)]
+  ;;   (doseq [job jobs]
+  ;;     (scheduler-put! job)))
+  (let [eids (get-eids-by-type db :variation/id)
+        jobs (make-batches 1000 :variation eids)]
     (doseq [job jobs]
       (scheduler-put! job)))
+
   )
 
 (defn schedule-jobs-all [db]
@@ -384,7 +389,7 @@
                     :delete-existing true)
       (let [db (d/db datomic-conn)]
         (do
-          (schedule-jobs-all db)
+          (schedule-jobs-sample db)
           (connect-snapshot-repository repository-name)
           (scheduler-put! (with-meta {} {:action "snapshot"
                                          :index index-id

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -111,6 +111,196 @@
 
 (defn- scheduler-retry! [& args] (apply dq/retry! args))
 
+(defn- scheduler-stats [] (dq/stats q))
+
+
+(defn run-index-sample [db]
+  ;; schedule something for testing
+  (let [eids (get-eids-by-type db :analysis/id)
+        jobs (make-batches 1000 :analysis eids)]
+    (doseq [job jobs]
+      (scheduler-put! job)))
+  )
+
+(defn run-index-all [db]
+  (do
+    ;; add jobs to scheduler in sequence
+
+    (let [eids (get-eids-by-type db :gene/id)
+          jobs (make-batches 100 :gene eids)]  ; smaller batch for slower ones
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :analysis/id)
+          jobs (make-batches 1000 :analysis eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :anatomy-term/id)
+          jobs (make-batches 1000 :anatomy-term eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :antibody/id)
+          jobs (make-batches 1000 :antibody eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :cds/id)
+          jobs (make-batches 1000 :cds eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :clone/id)
+          jobs (make-batches 1000 :clone eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :construct/id)
+          jobs (make-batches 1000 :construct eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :expression-cluster/id)
+          jobs (make-batches 1000 :expression-cluster eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :expr-pattern/id)
+          jobs (make-batches 1000 :expr-pattern eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :expr-profile/id)
+          jobs (make-batches 1000 :expr-profile eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :do-term/id)
+          jobs (make-batches 1000 :do-term eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :feature/id)
+          jobs (make-batches 1000 :feature eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :gene-class/id)
+          jobs (make-batches 1000 :gene-class eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :gene-cluster/id)
+          jobs (make-batches 1000 :gene-cluster eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :go-term/id)
+          jobs (make-batches 1000 :go-term eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :homology-group/id)
+          jobs (make-batches 1000 :homology-group eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :interaction/id)
+          jobs (make-batches 1000 :interaction eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :laboratory/id)
+          jobs (make-batches 1000 :laboratory eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :life-stage/id)
+          jobs (make-batches 1000 :life-stage eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :molecule/id)
+          jobs (make-batches 1000 :molecule eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :microarray-results/id)
+          jobs (make-batches 1000 :microarray-results eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :motif/id)
+          jobs (make-batches 1000 :motif eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :oligo/id)
+          jobs (make-batches 1000 :oligo eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :operon/id)
+          jobs (make-batches 1000 :operon eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :paper/id)
+          jobs (make-batches 1000 :paper eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :person/id)
+          jobs (make-batches 1000 :person eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :pcr-product/id)
+          jobs (make-batches 1000 :pcr-product eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :phenotype/id)
+          jobs (make-batches 1000 :phenotype eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :picture/id)
+          jobs (make-batches 1000 :picture eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :position-matrix/id)
+          jobs (make-batches 1000 :position-matrix eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :protein/id)
+          jobs (make-batches 1000 :protein eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :pseudogene/id)
+          jobs (make-batches 1000 :pseudogene eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :rearrangement/id)
+          jobs (make-batches 1000 :rearrangement eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :rnai/id)
+          jobs (make-batches 1000 :rnai eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :sequence/id)
+          jobs (make-batches 1000 :sequence eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :strain/id)
+          jobs (make-batches 1000 :strain eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :structure-data/id)
+          jobs (make-batches 1000 :structure-data eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :transcript/id)
+          jobs (make-batches 1000 :transcript eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :transgene/id)
+          jobs (make-batches 1000 :transgene eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :transposon/id)
+          jobs (make-batches 1000 :transposon eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :transposon-family/id)
+          jobs (make-batches 1000 :transposon-family eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :wbprocess/id)
+          jobs (make-batches 1000 :wbprocess eids)]
+      (doseq [job jobs]
+        (scheduler-put! job)))
+    (let [eids (get-eids-by-type db :variation/id)
+          jobs (make-batches 100 :variation eids)] ; smaller batch for slower ones
+      (doseq [job jobs]
+        (scheduler-put! job)))
+
+    ))
+
 
 (defn run [& {:keys [db index-revision-number index-id skip-create-snapshot]
               :or {db (d/db datomic-conn)
@@ -141,6 +331,7 @@
         (dotimes [i n-threads]
           (go
             (loop []
+              (>! logger (scheduler-stats))
               (if-let [job-ref (scheduler-take! 600000 nil)]
                 ;; normal batches won't be nil
                 ;; only get nil when channel is closed
@@ -156,183 +347,10 @@
                     (recur)))
                 (close! logger)))))
 
-        (do
-          ;; add jobs to scheduler in sequence
+        (run-index-all db)
+        ;;(run-index-sample db)
+        (prn (scheduler-stats))
 
-          (let [eids (get-eids-by-type db :gene/id)
-                jobs (make-batches 100 :gene eids)]  ; smaller batch for slower ones
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :analysis/id)
-                jobs (make-batches 1000 :analysis eids)]
-            (doseq [job jobs]
-               (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :anatomy-term/id)
-                jobs (make-batches 1000 :anatomy-term eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :antibody/id)
-                jobs (make-batches 1000 :antibody eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :cds/id)
-                jobs (make-batches 1000 :cds eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :clone/id)
-                jobs (make-batches 1000 :clone eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :construct/id)
-                jobs (make-batches 1000 :construct eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :expression-cluster/id)
-                jobs (make-batches 1000 :expression-cluster eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :expr-pattern/id)
-                jobs (make-batches 1000 :expr-pattern eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :expr-profile/id)
-                jobs (make-batches 1000 :expr-profile eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :do-term/id)
-                jobs (make-batches 1000 :do-term eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :feature/id)
-                jobs (make-batches 1000 :feature eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :gene-class/id)
-                jobs (make-batches 1000 :gene-class eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :gene-cluster/id)
-                jobs (make-batches 1000 :gene-cluster eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :go-term/id)
-                jobs (make-batches 1000 :go-term eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :homology-group/id)
-                jobs (make-batches 1000 :homology-group eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :interaction/id)
-                jobs (make-batches 1000 :interaction eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :laboratory/id)
-                jobs (make-batches 1000 :laboratory eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :life-stage/id)
-                jobs (make-batches 1000 :life-stage eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :molecule/id)
-                jobs (make-batches 1000 :molecule eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :microarray-results/id)
-                jobs (make-batches 1000 :microarray-results eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :motif/id)
-                jobs (make-batches 1000 :motif eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :oligo/id)
-                jobs (make-batches 1000 :oligo eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :operon/id)
-                jobs (make-batches 1000 :operon eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :paper/id)
-                jobs (make-batches 1000 :paper eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :person/id)
-                jobs (make-batches 1000 :person eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :pcr-product/id)
-                jobs (make-batches 1000 :pcr-product eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :phenotype/id)
-                jobs (make-batches 1000 :phenotype eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :picture/id)
-                jobs (make-batches 1000 :picture eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :position-matrix/id)
-                jobs (make-batches 1000 :position-matrix eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :protein/id)
-                jobs (make-batches 1000 :protein eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :pseudogene/id)
-                jobs (make-batches 1000 :pseudogene eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :rearrangement/id)
-                jobs (make-batches 1000 :rearrangement eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :rnai/id)
-                jobs (make-batches 1000 :rnai eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :sequence/id)
-                jobs (make-batches 1000 :sequence eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :strain/id)
-                jobs (make-batches 1000 :strain eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :structure-data/id)
-                jobs (make-batches 1000 :structure-data eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :transcript/id)
-                jobs (make-batches 1000 :transcript eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :transgene/id)
-                jobs (make-batches 1000 :transgene eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :transposon/id)
-                jobs (make-batches 1000 :transposon eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :transposon-family/id)
-                jobs (make-batches 1000 :transposon-family eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :wbprocess/id)
-                jobs (make-batches 1000 :wbprocess eids)]
-            (doseq [job jobs]
-              (scheduler-put! job)))
-          (let [eids (get-eids-by-type db :variation/id)
-                jobs (make-batches 100 :variation eids)] ; smaller batch for slower ones
-            (doseq [job jobs]
-              (scheduler-put! job)))
-
-          )
         )
 
       (if-not skip-create-snapshot

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -364,7 +364,7 @@
                                          :repository repository-name}))
           (->> (partial worker db)
                (repeatedly 4)
-               (map deref) ; wait for the futures to return
+               (pmap deref) ; wait for the futures to return
                (doall) ; force the side effects
                )
 

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -319,7 +319,7 @@
                (let [job (deref job-ref)
                      job-meta (meta job)]
                  (try
-                   (debug "Starting" (:action job-meta))
+                   (debug "Starting" job-meta)
                    (case (:action job-meta)
                      "snapshot" (let [index-id (:index job-meta)
                                       repository-name (:repository job-meta)

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -147,8 +147,12 @@
                 (let [job (deref job-ref)]
                   (do
                     (>! logger (or (meta job) :no_metadata))
-                    (run-index-batch db release-id job)
-                    (scheduler-complete! job-ref)
+                    (try
+                      (run-index-batch db release-id job)
+                      (scheduler-complete! job-ref)
+                      (catch Exception e
+                        ; retried items are added at the end of the queue
+                        (scheduler-retry! job-ref)))
                     (recur)))
                 (close! logger)))))
 

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -319,7 +319,11 @@
                 (case (:action job-meta)
                   "snapshot" (let [index-id (:index job-meta)
                                    repository-name (:repository job-meta)
-                                   snapshot-id (get-next-snapshot-id repository-name release-id)]
+                                   snapshot-id (get-next-snapshot-id repository-name release-id)
+                                   timeout 60000]
+                               (debug (format "Snapshot paused for %s ms for jobs to finish..." timeout))
+                               (Thread/sleep timeout) ; hack to allow other jobs to finish.
+                               (debug "Snapshot resumed")
                                (save-snapshot index-id repository-name snapshot-id)
                                (debug "Snapshot created" job-meta))
                   (do

--- a/src/wb_es/datomic/data/oligo.clj
+++ b/src/wb_es/datomic/data/oligo.clj
@@ -6,7 +6,8 @@
 
 (deftype Oligo [entity]
   data-util/Document
-  (metadata [this] (assoc (data-util/default-metadata entity) :_type "pcr-oligo"))
+  (metadata [this] (data-util/default-metadata entity))
   (data [this]
-    {:wbid (:oligo/id entity)
+    {:page_type "pcr-oligo"
+     :wbid (:oligo/id entity)
      :label (:oligo/id entity)}))


### PR DESCRIPTION
WormBase/website#7359

- use durable (disk-backed) job queue to aid debugging
- improve logging
- catching item specific errors in bulk request, and handle re-try
- fixing problems with indexing oligo type
- fixing snapshot being taken too early, before the jobs finish
