### PR TITLE
Removed snapshot capabilities

### DIFF
--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -14,7 +14,8 @@
             [wb-es.env :refer [es-base-url release-id]]
             [wb-es.mappings.core :refer [create-index]]
             [wb-es.web.setup :refer [es-connect]]
-            [wb-es.snapshot.core :refer [connect-snapshot-repository save-snapshot get-next-snapshot-id]]))
+            ; [wb-es.snapshot.core :refer [connect-snapshot-repository save-snapshot get-next-snapshot-id]]
+            ))
 
 (defn format-bulk
   "returns a new line delimited JSON based on
@@ -389,7 +390,7 @@
       (let [db (d/db datomic-conn)]
         (do
           (schedule-jobs-all db)
-          (connect-snapshot-repository repository-name)
+          ; (connect-snapshot-repository repository-name)
           (scheduler-put! (with-meta {} {:action "snapshot"
                                          :index index-id
                                          :repository repository-name}))

--- a/src/wb_es/bulk/core.clj
+++ b/src/wb_es/bulk/core.clj
@@ -344,12 +344,12 @@
                 (case (:action job-meta)
                   "snapshot" (let [index-id (:index job-meta)
                                    repository-name (:repository job-meta)
-                                   snapshot-id (get-next-snapshot-id repository-name release-id)
+                                   snapshot-id "1"
                                    timeout 60000]
                                (debug (format "Snapshot paused for %s ms for jobs to finish..." timeout))
                                (Thread/sleep timeout) ; hack to allow other jobs to finish.
                                (debug "Snapshot resumed")
-                               (save-snapshot index-id repository-name snapshot-id)
+                               ; (save-snapshot index-id repository-name snapshot-id)
                                (debug "Snapshot created" job-meta))
                   (let [job-report (run-index-batch db release-id job)]
                     (do

--- a/src/wb_es/env.clj
+++ b/src/wb_es/env.clj
@@ -9,6 +9,3 @@
 (def release-id
   (->> (re-find #"WS\d+" datomic-uri)
        (clojure.string/lower-case)))
-
-;(def restore-from-snapshot
-;  (env :restore-from-snapshot))  ; options: latest, snapshot_id, nil

--- a/src/wb_es/env.clj
+++ b/src/wb_es/env.clj
@@ -10,5 +10,5 @@
   (->> (re-find #"WS\d+" datomic-uri)
        (clojure.string/lower-case)))
 
-(def restore-from-snapshot
-  (env :restore-from-snapshot))  ; options: latest, snapshot_id, nil
+;(def restore-from-snapshot
+;  (env :restore-from-snapshot))  ; options: latest, snapshot_id, nil

--- a/src/wb_es/snapshot/core.clj
+++ b/src/wb_es/snapshot/core.clj
@@ -36,17 +36,17 @@
 ;          (last)
 ;          (:id))))
 
-; (defn get-next-snapshot-id
-;   [repository-name release-id]
-;   (let [pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))
-;         current-id (get-lateset-snapshot-id repository-name release-id :partial? true)
-;         next-version-id (if current-id
-;                           (->> (re-matches pattern current-id)
-;                                (last)
-;                                (Integer.)
-;                                (+ 1))
-;                           0)]
-;     (format "snapshot_%s_v%s" release-id next-version-id)))
+(defn get-next-snapshot-id
+  [repository-name release-id]
+  (let [pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))
+        current-id (get-lateset-snapshot-id repository-name release-id :partial? true)
+        next-version-id (if current-id
+                          (->> (re-matches pattern current-id)
+                               (last)
+                               (Integer.)
+                               (+ 1))
+                          0)]
+    (format "snapshot_%s_v%s" release-id next-version-id)))
 
 (defn save-snapshot
   [index-id repository-name snapshot-id]

--- a/src/wb_es/snapshot/core.clj
+++ b/src/wb_es/snapshot/core.clj
@@ -36,29 +36,29 @@
 ;          (last)
 ;          (:id))))
 
-(defn get-next-snapshot-id
-  [repository-name release-id]
-  (let [pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))
-        current-id (get-lateset-snapshot-id repository-name release-id :partial? true)
-        next-version-id (if current-id
-                          (->> (re-matches pattern current-id)
-                               (last)
-                               (Integer.)
-                               (+ 1))
-                          0)]
-    (format "snapshot_%s_v%s" release-id next-version-id)))
+; (defn get-next-snapshot-id
+;   [repository-name release-id]
+;   (let [pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))
+;         current-id (get-lateset-snapshot-id repository-name release-id :partial? true)
+;         next-version-id (if current-id
+;                           (->> (re-matches pattern current-id)
+;                                (last)
+;                                (Integer.)
+;                                (+ 1))
+;                           0)]
+;     (format "snapshot_%s_v%s" release-id next-version-id)))
 
-(defn save-snapshot
-  [index-id repository-name snapshot-id]
-  (let [snapshot-url (format "%s/_snapshot/%s/%s" es-base-url repository-name snapshot-id)]
-    (do
-      (println (format "Saving index %s to %s in repository %s" index-id snapshot-id repository-name))
-      (println (format "View progress with `curl -XGET %s`" snapshot-url))
-      (http/put (format "%s?wait_for_completion=true" snapshot-url)
-                {:headers {:content-type "application/json"}
-                 :body (json/generate-string {:indices index-id})}
-                )
-      )))
+; (defn save-snapshot
+;   [index-id repository-name snapshot-id]
+;   (let [snapshot-url (format "%s/_snapshot/%s/%s" es-base-url repository-name snapshot-id)]
+;     (do
+;       (println (format "Saving index %s to %s in repository %s" index-id snapshot-id repository-name))
+;       (println (format "View progress with `curl -XGET %s`" snapshot-url))
+;       (http/put (format "%s?wait_for_completion=true" snapshot-url)
+;                 {:headers {:content-type "application/json"}
+;                  :body (json/generate-string {:indices index-id})}
+;                 )
+;       )))
 
 ; (defn restore-snapshot
 ;   [index-id repository-name snapshot-id]

--- a/src/wb_es/snapshot/core.clj
+++ b/src/wb_es/snapshot/core.clj
@@ -4,49 +4,49 @@
             [cheshire.core :as json]
             [wb-es.env :refer [es-base-url release-id]]))
 
-(defn connect-snapshot-repository
-  ([repository-name]
-   (connect-snapshot-repository repository-name
-                                {"type" "s3"
-                                 "settings" {"bucket" "wormbase-elasticsearch-snapshots"
-                                             "region" "us-east-1"}}))
-  ([repository-name repository-settings]
-   (try
-     (http/put (format "%s/_snapshot/%s" es-base-url repository-name)
-               {:content-type "application/json"
-                :body (json/generate-string repository-settings)})
-     (catch Exception e
-       (throw (Exception. "Cannot connect to elasticsearch snapshot repository"))))))
+; (defn connect-snapshot-repository
+;   ([repository-name]
+;    (connect-snapshot-repository repository-name
+;                                 {"type" "s3"
+;                                  "settings" {"bucket" "wormbase-elasticsearch-snapshots"
+;                                              "region" "us-east-1"}}))
+;   ([repository-name repository-settings]
+;    (try
+;      (http/put (format "%s/_snapshot/%s" es-base-url repository-name)
+;                {:content-type "application/json"
+;                 :body (json/generate-string repository-settings)})
+;      (catch Exception e
+;        (throw (Exception. "Cannot connect to elasticsearch snapshot repository"))))))
 
-(defn get-lateset-snapshot-id
-  [repository-name release-id & {:keys [partial?]
-                                 :or {partial? false}}]
-  (let [response (http/get (format "%s/_cat/snapshots/%s?format=json" es-base-url repository-name))
-        all-snapshots (json/parse-string (:body response) true)
-        id-pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))]
-    (->> all-snapshots
-         (filter (fn [snapshot]
-                   (and
-                    (or partial?
-                        (= "SUCCESS" (:status snapshot)))
-                    (re-matches id-pattern (:id snapshot)))))
-         (sort-by (fn [snapshot]
-                    (let [[_ _ version-id] (re-matches id-pattern (:id snapshot))]
-                      (Integer. version-id))))
-         (last)
-         (:id))))
+; (defn get-lateset-snapshot-id
+;   [repository-name release-id & {:keys [partial?]
+;                                  :or {partial? false}}]
+;   (let [response (http/get (format "%s/_cat/snapshots/%s?format=json" es-base-url repository-name))
+;         all-snapshots (json/parse-string (:body response) true)
+;         id-pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))]
+;     (->> all-snapshots
+;          (filter (fn [snapshot]
+;                    (and
+;                     (or partial?
+;                         (= "SUCCESS" (:status snapshot)))
+;                     (re-matches id-pattern (:id snapshot)))))
+;          (sort-by (fn [snapshot]
+;                     (let [[_ _ version-id] (re-matches id-pattern (:id snapshot))]
+;                       (Integer. version-id))))
+;          (last)
+;          (:id))))
 
-(defn get-next-snapshot-id
-  [repository-name release-id]
-  (let [pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))
-        current-id (get-lateset-snapshot-id repository-name release-id :partial? true)
-        next-version-id (if current-id
-                          (->> (re-matches pattern current-id)
-                               (last)
-                               (Integer.)
-                               (+ 1))
-                          0)]
-    (format "snapshot_%s_v%s" release-id next-version-id)))
+; (defn get-next-snapshot-id
+;   [repository-name release-id]
+;   (let [pattern (re-pattern (format "snapshot_%s(_v(\\d+))?" release-id))
+;         current-id (get-lateset-snapshot-id repository-name release-id :partial? true)
+;         next-version-id (if current-id
+;                           (->> (re-matches pattern current-id)
+;                                (last)
+;                                (Integer.)
+;                                (+ 1))
+;                           0)]
+;     (format "snapshot_%s_v%s" release-id next-version-id)))
 
 (defn save-snapshot
   [index-id repository-name snapshot-id]
@@ -60,30 +60,30 @@
                 )
       )))
 
-(defn restore-snapshot
-  [index-id repository-name snapshot-id]
-  (let [max-retry 50
-        interval 10000
-        counter (atom 0)
-        connected (atom false)]
-    (do
-      (try
-        (http/post (format "%s/_snapshot/%s/%s/_restore" es-base-url repository-name snapshot-id))
-        (catch Exception e
-          (throw (Exception. (format "Failed to restore snapshot %s" snapshot-id)))))
-      (println "Restoring index started")
-      (while (not (deref connected))
-        (do
-          (swap! counter inc)
-          (try
-            (do
-              (println (http/get (format "%s/%s/_search" es-base-url index-id)))
-              (swap! connected not)
-              (println "Connected."))
-            (catch Exception e
-              (if (>= (deref counter) max-retry)
-                (throw (Exception. (format "Failed to connect to %s. Start up terminated." es-base-url)))
-                (do
-                  (println (http/get (format "%s/_cat/recovery?format=json" es-base-url repository-name)))
-                  (flush)
-                  (Thread/sleep interval))))))))))
+; (defn restore-snapshot
+;   [index-id repository-name snapshot-id]
+;   (let [max-retry 50
+;         interval 10000
+;         counter (atom 0)
+;         connected (atom false)]
+;     (do
+;       (try
+;         (http/post (format "%s/_snapshot/%s/%s/_restore" es-base-url repository-name snapshot-id))
+;         (catch Exception e
+;           (throw (Exception. (format "Failed to restore snapshot %s" snapshot-id)))))
+;       (println "Restoring index started")
+;       (while (not (deref connected))
+;         (do
+;           (swap! counter inc)
+;           (try
+;             (do
+;               (println (http/get (format "%s/%s/_search" es-base-url index-id)))
+;               (swap! connected not)
+;               (println "Connected."))
+;             (catch Exception e
+;               (if (>= (deref counter) max-retry)
+;                 (throw (Exception. (format "Failed to connect to %s. Start up terminated." es-base-url)))
+;                 (do
+;                   (println (http/get (format "%s/_cat/recovery?format=json" es-base-url repository-name)))
+;                   (flush)
+;                   (Thread/sleep interval))))))))))

--- a/src/wb_es/web/setup.clj
+++ b/src/wb_es/web/setup.clj
@@ -48,7 +48,7 @@
 
 (defn run
   "run setup"
-  ; ([] (run release-id restore-from-snapshot))
+  ([] (run release-id))
   ([release-id]
      (let [index-id release-id]
        (do

--- a/src/wb_es/web/setup.clj
+++ b/src/wb_es/web/setup.clj
@@ -54,15 +54,17 @@
            repository-name "s3_repository"]
        (do
          (es-connect)
-         (connect-snapshot-repository repository-name)
-         (if (has-index index-id)
-           (println (format "Elasticsearch index %s is found locally. No attempt will be made to restore snapshots." index-id))
-           (if snapshot
-             (let [snapshot-id (if (= "latest" snapshot)
-                                 (get-lateset-snapshot-id repository-name release-id)
-                                 snapshot)]
-               (restore-snapshot index-id repository-name snapshot-id)
-               (println (format "Elasticsearch is restored from snapshot %s" snapshot-id)))))))))
+;         (connect-snapshot-repository repository-name)
+         (if (has-index index-id) println "Index should be set"
+;           (println (format "Elasticsearch index %s is found locally. No attempt will be made to restore snapshots." index-id))
+;           (if snapshot
+;             (let [snapshot-id (if (= "latest" snapshot)
+;                                 (get-lateset-snapshot-id repository-name release-id)
+;                                 snapshot)]
+;               (restore-snapshot index-id repository-name snapshot-id)
+;               (println (format "Elasticsearch is restored from snapshot %s" snapshot-id))))
+           )
+         ))))
 
 (defn -main
   "I don't do a whole lot ... yet."

--- a/src/wb_es/web/setup.clj
+++ b/src/wb_es/web/setup.clj
@@ -2,7 +2,7 @@
   (:gen-class)
   (:require [clj-http.client :as http]
             [cheshire.core :as json]
-            [wb-es.env :refer [es-base-url release-id restore-from-snapshot]]
+            [wb-es.env :refer [es-base-url release-id]]
             ; [wb-es.snapshot.core :refer [connect-snapshot-repository
             ;                              get-lateset-snapshot-id
             ;                              restore-snapshot]]
@@ -49,9 +49,8 @@
 (defn run
   "run setup"
   ; ([] (run release-id restore-from-snapshot))
-  ([release-id snapshot]
-     (let [index-id release-id
-           repository-name "s3_repository"]
+  ([release-id]
+     (let [index-id release-id]
        (do
          (es-connect)
 ;         (connect-snapshot-repository repository-name)

--- a/src/wb_es/web/setup.clj
+++ b/src/wb_es/web/setup.clj
@@ -3,9 +3,9 @@
   (:require [clj-http.client :as http]
             [cheshire.core :as json]
             [wb-es.env :refer [es-base-url release-id restore-from-snapshot]]
-            [wb-es.snapshot.core :refer [connect-snapshot-repository
-                                         get-lateset-snapshot-id
-                                         restore-snapshot]]
+            ; [wb-es.snapshot.core :refer [connect-snapshot-repository
+            ;                              get-lateset-snapshot-id
+            ;                              restore-snapshot]]
             ))
 
 
@@ -48,7 +48,7 @@
 
 (defn run
   "run setup"
-  ([] (run release-id restore-from-snapshot))
+  ; ([] (run release-id restore-from-snapshot))
   ([release-id snapshot]
      (let [index-id release-id
            repository-name "s3_repository"]

--- a/src/wb_es/web/setup.clj
+++ b/src/wb_es/web/setup.clj
@@ -3,9 +3,6 @@
   (:require [clj-http.client :as http]
             [cheshire.core :as json]
             [wb-es.env :refer [es-base-url release-id]]
-            ; [wb-es.snapshot.core :refer [connect-snapshot-repository
-            ;                              get-lateset-snapshot-id
-            ;                              restore-snapshot]]
             ))
 
 
@@ -53,15 +50,7 @@
      (let [index-id release-id]
        (do
          (es-connect)
-;         (connect-snapshot-repository repository-name)
          (if (has-index index-id) println "Index should be set"
-;           (println (format "Elasticsearch index %s is found locally. No attempt will be made to restore snapshots." index-id))
-;           (if snapshot
-;             (let [snapshot-id (if (= "latest" snapshot)
-;                                 (get-lateset-snapshot-id repository-name release-id)
-;                                 snapshot)]
-;               (restore-snapshot index-id repository-name snapshot-id)
-;               (println (format "Elasticsearch is restored from snapshot %s" snapshot-id))))
            )
          ))))
 


### PR DESCRIPTION
Most code that used to load the snapshot from S3 is removed. It was commented out on previous commits, now removed.

With the exception of the file in `src/wb-es/snapshot` where the code was kept for historical reason. A new pass should be made to remove links to files in this directory to make the code more elegant.

Also, more changes are needed on the indexing side to NOT create the snapshot. I will update the documentation on GDocs and on the README.md file on the strategy changes from EB to an EC2 deployed instance.